### PR TITLE
[Refactor] #35 식단 수정 API 단일 수정 방식에서 다건 수정 방식으로 변경

### DIFF
--- a/src/main/java/com/urisik/backend/domain/familyroom/controller/FamilyRoomController.java
+++ b/src/main/java/com/urisik/backend/domain/familyroom/controller/FamilyRoomController.java
@@ -38,7 +38,7 @@ public class FamilyRoomController {
     }
 
     @GetMapping("/family-rooms/me")
-    @Operation(summary = "가족방 조회 API")
+    @Operation(summary = "가족방 컨텍스트 조회 API")
     public ApiResponse<ReadFamilyRoomContextResDTO> readMyFamilyRoomContext(
             @AuthenticationPrincipal Long memberId
     ) {

--- a/src/main/java/com/urisik/backend/domain/mealplan/dto/req/CreateMealPlanReqDTO.java
+++ b/src/main/java/com/urisik/backend/domain/mealplan/dto/req/CreateMealPlanReqDTO.java
@@ -14,7 +14,7 @@ public record CreateMealPlanReqDTO(
         boolean regenerate
 ) {
     public record SlotRequest(
-            @NotNull DayOfWeek dayOfWeek,
-            @NotNull MealType mealType
+            @NotNull MealType mealType,
+            @NotNull DayOfWeek dayOfWeek
     ) {}
 }

--- a/src/main/java/com/urisik/backend/domain/mealplan/dto/req/UpdateMealPlanReqDTO.java
+++ b/src/main/java/com/urisik/backend/domain/mealplan/dto/req/UpdateMealPlanReqDTO.java
@@ -4,13 +4,18 @@ import com.urisik.backend.domain.mealplan.enums.MealType;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.DayOfWeek;
+import java.util.List;
 
 public record UpdateMealPlanReqDTO(
-        @NotNull SlotRequest slot,
-        @NotNull RecipeSelectionDTO selectedRecipe
+        @NotNull List<UpdateItem> updates
 ) {
+    public record UpdateItem(
+            @NotNull SlotRequest selectedSlot,
+            @NotNull RecipeSelectionDTO selectedRecipe
+    ) {}
+
     public record SlotRequest(
-            @NotNull DayOfWeek dayOfWeek,
-            @NotNull MealType mealType
+            @NotNull MealType mealType,
+            @NotNull DayOfWeek dayOfWeek
     ) {}
 }

--- a/src/main/java/com/urisik/backend/domain/mealplan/dto/res/UpdateMealPlanResDTO.java
+++ b/src/main/java/com/urisik/backend/domain/mealplan/dto/res/UpdateMealPlanResDTO.java
@@ -12,6 +12,24 @@ import lombok.Getter;
 public class UpdateMealPlanResDTO {
     private Long mealPlanId;
     private MealPlanStatus status;
-    private String updatedSlotKey;
-    private RecipeDTO recipe;
+    private java.util.List<UpdatedSlot> updatedSlots;
+
+    public static UpdateMealPlanResDTO bulk(
+            Long mealPlanId,
+            MealPlanStatus status,
+            java.util.List<UpdatedSlot> updatedSlots
+    ) {
+        return UpdateMealPlanResDTO.builder()
+                .mealPlanId(mealPlanId)
+                .status(status)
+                .updatedSlots(updatedSlots)
+                .build();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class UpdatedSlot {
+        private String slotKey;   // e.g. DINNER-MONDAY
+        private RecipeDTO recipe;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #35 

## 📝작업 내용

> 식단 수정 API 단일 수정 방식에서 다건 수정 방식으로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meal plan updates now support modifying multiple meal slots simultaneously in one operation.

* **Improvements**
  * Standardized meal display order across meal plan views—Lunch consistently appears before Dinner.

* **Documentation**
  * Updated family room endpoint description for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->