### PR TITLE
[Feat] #128 알림 읽음 처리 API 구현

### DIFF
--- a/src/main/java/com/urisik/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/urisik/backend/domain/notification/controller/NotificationController.java
@@ -1,19 +1,18 @@
 package com.urisik.backend.domain.notification.controller;
 
+import com.urisik.backend.domain.notification.dto.NotificationReadResDto;
 import com.urisik.backend.domain.notification.dto.NotificationResDto;
 import com.urisik.backend.domain.notification.exception.NotificationSuccessCode;
 import com.urisik.backend.domain.notification.service.NotificationService;
 import com.urisik.backend.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
@@ -49,5 +48,20 @@ public class NotificationController {
     ) {
         Slice<NotificationResDto> result = notificationService.getNotifications(memberId, size);
         return ApiResponse.onSuccess(NotificationSuccessCode.NOTIFICATION_GET_SUCCESS, result);
+    }
+
+
+    /**
+     * 3. 알림 "읽음" 상태로 변경
+     * @param memberId
+     */
+    @PatchMapping(value = "/{notificationId}/read")
+    @Operation(summary = "알림 읽음 처리 API", description = "알림 읽음 상태를 true로 변경합니다. ")
+    public ApiResponse<NotificationReadResDto> readNotification(
+            @PathVariable(name = "notificationId") Long notificationId,
+            @AuthenticationPrincipal Long memberId
+            ) {
+        return ApiResponse.onSuccess(NotificationSuccessCode.NOTIFICATION_READ_SUCCESS,
+                notificationService.readNotification(memberId, notificationId));
     }
 }

--- a/src/main/java/com/urisik/backend/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/urisik/backend/domain/notification/converter/NotificationConverter.java
@@ -1,5 +1,6 @@
 package com.urisik.backend.domain.notification.converter;
 
+import com.urisik.backend.domain.notification.dto.NotificationReadResDto;
 import com.urisik.backend.domain.notification.dto.NotificationResDto;
 import com.urisik.backend.domain.notification.entity.Notification;
 import org.springframework.data.domain.Slice;
@@ -22,5 +23,11 @@ public class NotificationConverter {
                 .build();
     }
 
+    // 알림 읽음 처리
+    public static NotificationReadResDto toNotificationReadResDto(Notification notification) {
+        return NotificationReadResDto.builder()
+                .isRead(notification.isRead())
+                .build();
+    }
 
 }

--- a/src/main/java/com/urisik/backend/domain/notification/dto/NotificationReadResDto.java
+++ b/src/main/java/com/urisik/backend/domain/notification/dto/NotificationReadResDto.java
@@ -1,0 +1,9 @@
+package com.urisik.backend.domain.notification.dto;
+
+import lombok.Builder;
+
+@Builder
+public record NotificationReadResDto(
+        boolean isRead
+) {
+}

--- a/src/main/java/com/urisik/backend/domain/notification/dto/NotificationReqDto.java
+++ b/src/main/java/com/urisik/backend/domain/notification/dto/NotificationReqDto.java
@@ -1,4 +1,0 @@
-package com.urisik.backend.domain.notification.dto;
-
-public record NotificationReqDto () {
-}

--- a/src/main/java/com/urisik/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/urisik/backend/domain/notification/entity/Notification.java
@@ -6,6 +6,8 @@ import com.urisik.backend.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -18,10 +20,10 @@ public class Notification extends BaseEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
+    @Column(name = "type", nullable = false, length = 20)
     private NotificationType type;
 
-    @Column(name = "is_read")
+    @Column(name = "is_read", nullable = false)
     private boolean isRead = false;
 
     @Column(name = "meal_plan_generation_count")
@@ -31,4 +33,9 @@ public class Notification extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+
+
+    public void updateIsRead(boolean isRead) {
+        this.isRead = isRead;
+    }
 }

--- a/src/main/java/com/urisik/backend/domain/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/urisik/backend/domain/notification/exception/NotificationErrorCode.java
@@ -16,7 +16,11 @@ public enum NotificationErrorCode implements BaseErrorCode {
 
     NOTIFICATION_SUBSCRIBE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,
             "NOTI_500_2",
-            "SSE 구독 연결 중 오류가 발생했습니다.");
+            "SSE 구독 연결 중 오류가 발생했습니다."),
+
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "NOTI_404_1",
+            "존재하지 않는 알림입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/urisik/backend/domain/notification/exception/NotificationSuccessCode.java
+++ b/src/main/java/com/urisik/backend/domain/notification/exception/NotificationSuccessCode.java
@@ -17,7 +17,13 @@ public enum NotificationSuccessCode implements BaseSuccessCode {
 
      NOTIFICATION_GET_SUCCESS(HttpStatus.OK,
             "NOTI_200_2",
-            "알림 목록 조회 성공");
+            "알림 목록 조회 성공"),
+
+    NOTIFICATION_READ_SUCCESS(HttpStatus.OK,
+            "NOTI_200_3",
+            "알림 읽음 처리 성공");
+
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/urisik/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/urisik/backend/domain/notification/repository/NotificationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     Slice<Notification> findAllByMember(Member member, Pageable pageable);
@@ -18,4 +19,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Transactional
     @Query("delete from Notification n where n.createAt < :deleteDate")
     void deleteNotifications(LocalDateTime deleteDate);
+
+    Optional<Notification> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/urisik/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/urisik/backend/domain/notification/service/NotificationService.java
@@ -3,6 +3,7 @@ package com.urisik.backend.domain.notification.service;
 import com.urisik.backend.domain.member.entity.Member;
 import com.urisik.backend.domain.member.repo.MemberRepository;
 import com.urisik.backend.domain.notification.converter.NotificationConverter;
+import com.urisik.backend.domain.notification.dto.NotificationReadResDto;
 import com.urisik.backend.domain.notification.dto.NotificationResDto;
 import com.urisik.backend.domain.notification.entity.Notification;
 import com.urisik.backend.domain.notification.enums.NotificationType;
@@ -80,6 +81,23 @@ public class NotificationService {
 
         return NotificationConverter.toNotificationResponseListDto(notifications);
 
+
+    }
+
+    /**
+     * 3.알림 읽음 처리 메서드
+     * @param memberId
+     * */
+    @Transactional
+    public NotificationReadResDto readNotification(Long memberId, Long notificationId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AuthenExcetion(AuthErrorCode.NO_MEMBER));
+
+        Notification notification = notificationRepository.findByIdAndMember(notificationId, member)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+        notification.updateIsRead(true);
+        return NotificationConverter.toNotificationReadResDto(notification);
 
     }
 

--- a/src/main/java/com/urisik/backend/domain/review/controller/TransformedReviewController.java
+++ b/src/main/java/com/urisik/backend/domain/review/controller/TransformedReviewController.java
@@ -7,6 +7,7 @@ import com.urisik.backend.domain.review.service.TransformedReviewService;
 import com.urisik.backend.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +27,7 @@ public class TransformedReviewController {
     )
     public ApiResponse<ReviewResponseDto> createReview(
             @PathVariable Long transformedRecipeId,
-            @RequestBody ReviewRequestDto request,
+            @RequestBody @Valid ReviewRequestDto request,
             @AuthenticationPrincipal Long memberId
     ) {
         ReviewResponseDto response =


### PR DESCRIPTION
## #️⃣연관된 이슈

#128 

## 📝작업 내용

patch 요청 시 해당 알림의 isRead 필드 값을 true로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to mark individual notifications as read through a dedicated API endpoint.

* **Improvements**
  * Enhanced notification data validation and error handling with better messaging for non-existent notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->